### PR TITLE
Fix feof() null stream crash and broken response headers in AssetController

### DIFF
--- a/src/Http/Controllers/AssetController.php
+++ b/src/Http/Controllers/AssetController.php
@@ -6,12 +6,17 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Statikbe\FilamentFlexibleBlocksAssetManager\FilamentFlexibleBlocksAssetManagerConfig;
 use Statikbe\FilamentFlexibleBlocksAssetManager\Models\Asset;
+use Symfony\Component\HttpFoundation\HeaderUtils;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class AssetController
 {
+    private const STREAM_CHUNK_SIZE = 1024 * 1024;
+
     public function index(Request $request, string $assetId, ?string $locale = null)
     {
         $asset = FilamentFlexibleBlocksAssetManagerConfig::getModel()::findOrFail($assetId);
@@ -26,7 +31,7 @@ class AssetController
 
         $assetMedia = $this->getAssetMedia($asset, $locale);
 
-        if (! $assetMedia || ! Storage::disk($assetMedia->disk)->exists($assetMedia->getPathRelativeToRoot())) {
+        if (! $assetMedia) {
             abort(Response::HTTP_NOT_FOUND, trans('filament-flexible-blocks-asset-manager::filament-flexible-blocks-asset-manager.error.asset_media_not_found'));
         }
 
@@ -36,15 +41,49 @@ class AssetController
             $conversion = null;
         }
 
-        $downloadFileName = $asset->getDownloadFileName();
-        if ($downloadFileName) {
-            $assetMedia->file_name = $downloadFileName;
+        $diskName = $conversion ? $assetMedia->conversions_disk : $assetMedia->disk;
+        $path = $assetMedia->getPathRelativeToRoot($conversion ?? '');
+        $disk = Storage::disk($diskName);
+
+        if (! $disk->exists($path)) {
+            abort(Response::HTTP_NOT_FOUND, trans('filament-flexible-blocks-asset-manager::filament-flexible-blocks-asset-manager.error.asset_media_not_found'));
         }
 
-        return $assetMedia
-            ->toInlineResponse($request, $conversion ?? '')
-            ->withHeaders(['X-Robots-Tag' => 'none']);
+        // Spatie's buildResponse() calls feof() on the stream without a null guard,
+        // so a flysystem adapter returning false here would fatal mid-response.
+        $stream = $disk->readStream($path);
+        if (! is_resource($stream)) {
+            abort(Response::HTTP_NOT_FOUND, trans('filament-flexible-blocks-asset-manager::filament-flexible-blocks-asset-manager.error.asset_media_not_found'));
+        }
 
+        $fileName = $asset->getDownloadFileName() ?: $assetMedia->file_name;
+        $size = $conversion ? $disk->size($path) : $assetMedia->size;
+
+        return new StreamedResponse(function () use ($stream) {
+            try {
+                while (! feof($stream)) {
+                    echo fread($stream, self::STREAM_CHUNK_SIZE);
+                    flush();
+                }
+            } finally {
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
+            }
+        }, Response::HTTP_OK, [
+            'Content-Type' => $assetMedia->mime_type,
+            'Content-Length' => $size,
+            'Content-Disposition' => $this->buildContentDisposition($fileName),
+            'Cache-Control' => 'private, no-cache',
+            'X-Robots-Tag' => 'none',
+        ]);
+    }
+
+    private function buildContentDisposition(string $fileName): string
+    {
+        $safeFileName = str_replace(['/', '\\'], '_', $fileName);
+
+        return HeaderUtils::makeDisposition('inline', $safeFileName, Str::ascii($safeFileName));
     }
 
     private function getAssetMedia(Asset $asset, ?string $locale = null): ?Media

--- a/tests/Feature/AssetControllerTest.php
+++ b/tests/Feature/AssetControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
 use Orchestra\Testbench\Factories\UserFactory;
 use Statikbe\FilamentFlexibleBlocksAssetManager\Models\Asset;
@@ -13,17 +14,83 @@ it('returns asset media file successfully', function () {
     $response->assertOk();
 });
 
-it('sets X-Robots-Tag none header on media custom properties', function () {
+it('sets X-Robots-Tag none header on the response', function () {
     setupFakeStorage();
     $asset = createAsset(withMedia: true);
 
     $response = $this->get(route('filament-flexible-blocks-asset-manager.asset_index', ['assetId' => $asset->id]));
 
     $response->assertOk();
-    // The controller calls setCustomHeaders on the media model which stores the
-    // headers as custom properties (used for cloud storage headers like S3).
-    // Spatie's toResponse() does not include them in the HTTP response headers.
+    $response->assertHeader('X-Robots-Tag', 'none');
     $response->assertHeader('Content-Disposition');
+});
+
+it('streams the file content in the response body', function () {
+    setupFakeStorage();
+    $asset = createAsset(withMedia: true);
+
+    $response = $this->get(route('filament-flexible-blocks-asset-manager.asset_index', ['assetId' => $asset->id]));
+
+    $response->assertOk();
+    expect($response->streamedContent())->toBe('test file content');
+});
+
+it('sets Content-Type from the media mime type', function () {
+    setupFakeStorage();
+    $asset = createAsset(withMedia: true);
+    $media = $asset->getFirstMedia($asset->getAssetCollection());
+
+    $response = $this->get(route('filament-flexible-blocks-asset-manager.asset_index', ['assetId' => $asset->id]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toContain($media->mime_type);
+});
+
+it('sets Content-Disposition inline with the filename', function () {
+    setupFakeStorage();
+    $asset = createAsset(withMedia: true);
+
+    $response = $this->get(route('filament-flexible-blocks-asset-manager.asset_index', ['assetId' => $asset->id]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Disposition'))
+        ->toContain('inline')
+        ->toContain('test-file.pdf');
+});
+
+it('sets Content-Length matching the media size', function () {
+    setupFakeStorage();
+    $asset = createAsset(withMedia: true);
+    $media = $asset->getFirstMedia($asset->getAssetCollection());
+
+    $response = $this->get(route('filament-flexible-blocks-asset-manager.asset_index', ['assetId' => $asset->id]));
+
+    $response->assertOk();
+    $response->assertHeader('Content-Length', (string) $media->size);
+});
+
+// Status-level guard test: verifies the 404 short-circuit when readStream() returns
+// null despite exists() being true. Does not exercise the streaming closure body —
+// the streamed-content test above covers the happy path.
+it('returns 404 when readStream returns null despite the file existing', function () {
+    setupFakeStorage();
+    $asset = createAsset(withMedia: true);
+    $media = $asset->getFirstMedia($asset->getAssetCollection());
+
+    Storage::shouldReceive('disk')
+        ->with($media->disk)
+        ->andReturn(Mockery::mock(FilesystemAdapter::class, function ($mock) use ($media) {
+            $mock->shouldReceive('exists')
+                ->with($media->getPathRelativeToRoot())
+                ->andReturn(true);
+            $mock->shouldReceive('readStream')
+                ->with($media->getPathRelativeToRoot())
+                ->andReturn(null);
+        }));
+
+    $response = $this->get(route('filament-flexible-blocks-asset-manager.asset_index', ['assetId' => $asset->id]));
+
+    $response->assertNotFound();
 });
 
 it('returns 404 for non-existent asset', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,7 +16,6 @@ use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 use Spatie\Translatable\TranslatableServiceProvider;
 use Statikbe\FilamentFlexibleBlocksAssetManager\FilamentFlexibleBlocksAssetManagerServiceProvider;
@@ -50,7 +49,6 @@ class TestCase extends Orchestra
             TablesServiceProvider::class,
             WidgetsServiceProvider::class,
             LivewireServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             MediaLibraryServiceProvider::class,
             TranslatableServiceProvider::class,
             FilamentFlexibleContentBlocksServiceProvider::class,


### PR DESCRIPTION
## Summary

Fixes two latent bugs in `AssetController::index` when serving asset media:

- **`feof()` null-stream crash.** Spatie's `Media::buildResponse()` (called via `toInlineResponse()`) loops on `feof($stream)` with no null guard. If the flysystem adapter returns `false` from `readStream()` (file vanished between checks, broken adapter, permission flip), the response closure fatals mid-flight.
- **`X-Robots-Tag` never reached the browser.** The controller chained `->withHeaders([...])` onto the Symfony `StreamedResponse` returned by `toInlineResponse()`. That method only exists on `Illuminate\Http\Response`, so every successful asset request was actually erroring before reaching the client.

## What changed

- Replaced `toInlineResponse()` with an explicit `StreamedResponse` that pre-opens `readStream()` and 404s when it doesn't return a resource.
- Existing features preserved: `?conversion=` query param, `Asset::getDownloadFileName()` override, gate-based authorization, locale fallback.
- Headers (`Content-Type`, `Content-Length`, `Content-Disposition`, `Cache-Control`, `X-Robots-Tag`) set directly on the response so they actually reach the browser.
- `Content-Length` derived from `Storage::disk($conversions_disk)->size($path)` for conversions, matching Spatie's own behavior.
- `HeaderUtils::makeDisposition()` with sanitized filename + ASCII fallback (avoids `InvalidArgumentException` if a filename contains `/` or `\`).
- Streaming loop wrapped in `try/finally` with an `is_resource()` guard so the stream is always closed.
- Cleanup: removed the `BladeCaptureDirectiveServiceProvider` registration in tests — the package is no longer a dependency, so its presence was fataling every test run.

## Commits

1. `cf415a6` Remove unused BladeCaptureDirective service provider
2. `2eda94e` Fix feof() null stream crash and broken response headers in AssetController
3. `8da0f2f` Add test coverage for streamed asset response and error paths

## Test plan

- [x] `vendor/bin/pest` — 98 tests pass (16 in `AssetControllerTest`, including new tests for streamed body, `Content-Type`/`Disposition`/`Length`, `X-Robots-Tag` response header, and the `readStream()`-returns-null 404 short-circuit).
- [x] `vendor/bin/phpstan analyse` — no errors.